### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gdpr.yml
+++ b/.github/workflows/gdpr.yml
@@ -10,6 +10,8 @@ jobs:
   gdpr-check:
     name: 🔒 GDPR Checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: 📥 Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/gilmry/ecolehub/security/code-scanning/1](https://github.com/gilmry/ecolehub/security/code-scanning/1)

To fix the problem, we should add a `permissions:` block to the workflow, restricting GitHub Actions runner permissions for this job. Since the `gdpr-check` job is only running tests and does not upload artifacts, create deployments, or write to the repo, it needs only read access to the repository contents. The least-privilege fix is to set `permissions: contents: read` at either the workflow root or the job level; adding it at the job level ensures explicitness. The change should be made to the `.github/workflows/gdpr.yml` file, by adding the following lines under the `gdpr-check` job, between `runs-on:` and `steps:`.

No imports, new methods, or definitions are required for this YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
